### PR TITLE
Refactoring for a restrictive environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,6 @@ FROM scratch
 COPY --from=build-kubectl /kubectl .
 COPY --from=build-env /go/src/github.com/mhausenblas/kboom/kboom .
 COPY --from=build-env /etc/passwd /etc/passwd
-USER kboom
+# We need to specify the UID otherwise PSP won't recognize it
+USER 10001
 ENTRYPOINT ["/kboom"]

--- a/kboom
+++ b/kboom
@@ -7,6 +7,8 @@ function genload {
 namespace=$1
 mode=$2
 load=$3
+kboom_image=$4
+image=$5
 
 # echo using namespace=\"$namespace\", mode \"$mode\", and load \"$load\"
 
@@ -23,12 +25,13 @@ spec:
       serviceAccountName: kboom-sa
       containers:
       - name: kboom
-        image: quay.io/mhausenblas/kboom:1
+        image: $kboom_image
         command:
         - "/kboom"
         - "--namespace=$namespace"
         - "--mode=$mode"
         - "--load=$load"
+        - "--image=$image"
       restartPolicy: Never
 EOF
 
@@ -45,6 +48,8 @@ command="${1:-results}"
 namespace="kboom"
 mode="scale:20"
 load="pods:1"
+kboom_image="quay.io/mhausenblas/kboom:1"
+image="busybox"
 
 ################################################################################
 ### MAIN #######################################################################
@@ -60,6 +65,12 @@ while [ $# -gt 0 ]; do
     --load=*)
       load="${1#*=}"
       ;;
+    --kboom-image=*)
+      kboom_image="${1#*=}"
+      ;;
+    --image=*)
+      image="${1#*=}"
+      ;;
   esac
   shift
 done
@@ -67,7 +78,7 @@ done
 
 case $command in
 generate)
-  genload $namespace $mode $load
+  genload $namespace $mode $load $kboom_image $image
   ;;
 results)
   kubectl -n $namespace logs job/kboom
@@ -78,4 +89,3 @@ cleanup)
 *)
   printf "The [$COMMAND] command is not supported! Use 'generate' to generate some load, 'results' to view the results, or 'cleanup' to clean up all resources.\n"
 esac
-

--- a/main.go
+++ b/main.go
@@ -15,9 +15,11 @@ func main() {
 	var namespace string
 	var mode string
 	var load string
+	var image string
 	flag.StringVar(&namespace, "namespace", "kboom", "The namespace to run in, must exist. Create with 'kubectl create ns' if not done yet.")
 	flag.StringVar(&mode, "mode", "scale:20", "The mode to operate in: 'scale' for perf testing, 'soak' for long-term testing with timeout in seconds, defaults to scale:20.")
 	flag.StringVar(&load, "load", "pods:1", "The load, as in number of pods, defaults to pods:1.")
+	flag.StringVar(&image, "image", "busybox", "The container image used for the test pods. Must contain /bin/sh and sleep, defaults to busybox.")
 	flag.Parse()
 	res, _ := kubecuddler.Kubectl(false, false, "/kubectl", "version", "--short")
 	fmt.Println(strings.Split(res, "\n")[1])
@@ -32,7 +34,7 @@ func main() {
 	switch testmode {
 	case "scale":
 		if numpods > 0 {
-			r := launchPods(client, namespace, timeoutinsec, numpods)
+			r := launchPods(client, namespace, image, timeoutinsec, numpods)
 			fmt.Printf("Overall pods successful: %v out of %v\n", r.Totalsuccess, numpods)
 			fmt.Printf("Total runtime: %v\n", r.Totaltime)
 			fmt.Printf("Fastest pod: %v\n", r.Min)

--- a/permissions.yaml
+++ b/permissions.yaml
@@ -5,14 +5,26 @@ metadata:
   name: kboom-sa  
   namespace: kboom
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kboom
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "pods"
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kboom-crb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: kboom
 subjects:
 - kind: ServiceAccount
   name: kboom-sa


### PR DESCRIPTION
Currently I'm working in a restrictive environment and would like to use kboom to perform some benchmarks in our Kubernetes clusters. Some of the limitations we have:

- Enabled PSP (no root is allowed)
- Only container images from a private registry are allowed
- `cluster-admin` shouldn't be used for tooling

I refactored some of the scripts/code to make it usable in our restrictive environment. kboom can still be used like before (in "normal" environments).