### PR TITLE
Implement early exit

### DIFF
--- a/kboom
+++ b/kboom
@@ -84,7 +84,8 @@ results)
   kubectl -n $namespace logs job/kboom
   ;;
 cleanup)
-  kubectl -n $namespace delete job/kboom
+  kubectl -n $namespace delete --ignore-not-found job/kboom
+  kubectl -n $namespace delete pods -l generator=kboom
   ;;
 *)
   printf "The [$COMMAND] command is not supported! Use 'generate' to generate some load, 'results' to view the results, or 'cleanup' to clean up all resources.\n"

--- a/pods.go
+++ b/pods.go
@@ -51,6 +51,7 @@ func launchPods(client *k8s.Client, namespace, image string, timeoutinsec time.D
 	c := tachymeter.New(&tachymeter.Config{Size: numpods})
 	start := time.Now()
 	var podruns []*podrun
+	successfulPods := 0
 
 	// launch the pods in parallel, as fast as we can:
 	for i := 0; i < numpods; i++ {
@@ -89,6 +90,11 @@ Check:
 					if !podruns[name2ord(podname)].Success {
 						podruns[name2ord(podname)].End = time.Now()
 						podruns[name2ord(podname)].Success = true
+						successfulPods++
+
+						if successfulPods == numpods {
+							break Check
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The current logic was waiting until the timeout was triggered which means if you set your timeout pretty high you have to wait for a pretty long time (even if all pods came up). This PR simply checks if all Pods came up and then leaves the loop.

Also I added a small fix for the cleanup functionality to also delete Pods that are created by the kboom job.