### PR TITLE
WIP: Initial support for pod template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add git                                   && \
     go get github.com/ericchiang/k8s              && \
     go get github.com/mhausenblas/kubecuddler     && \
     go get github.com/jamiealquiza/tachymeter     && \
+    go get k8s.io/apimachinery/pkg/...            && \
     mkdir -p /go/src/github.com/mhausenblas/kboom
 
 WORKDIR /go/src/github.com/mhausenblas/kboom

--- a/kboom
+++ b/kboom
@@ -14,6 +14,16 @@ image=$5
 
 tmpdir=$(mktemp -d)
 
+cat <<EOF >> ${tmpdir}/kboom-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kboom-template
+data:
+  template.yaml: |
+$(sed 's/^/    /' ${PWD}/manifests/pod_default.yaml)
+EOF
+
 cat <<EOF >> ${tmpdir}/kboom-job.yaml
 apiVersion: batch/v1
 kind: Job
@@ -23,6 +33,7 @@ spec:
   template:
     spec:
       serviceAccountName: kboom-sa
+      restartPolicy: Never
       containers:
       - name: kboom
         image: $kboom_image
@@ -32,12 +43,19 @@ spec:
         - "--mode=$mode"
         - "--load=$load"
         - "--image=$image"
-      restartPolicy: Never
+        volumeMounts:
+        - name: kboom-template
+          mountPath: /tmp/template
+          readOnly: True
+      volumes:
+      - name: kboom-template
+        configMap:
+          name: kboom-template
 EOF
 
-# cat ${tmpdir}/kboom-job.yaml
+cat ${tmpdir}/kboom-job.yaml
 
-kubectl -n $namespace apply -f ${tmpdir}/kboom-job.yaml
+kubectl -n $namespace apply -f ${tmpdir}/kboom-job.yaml -f  ${tmpdir}/kboom-template.yaml
 }
 
 

--- a/manifests/pod_default.yaml
+++ b/manifests/pod_default.yaml
@@ -1,0 +1,10 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: dummy
+spec:
+  containers:
+  - name: main
+    command: ["/bin/sh", "-ec", "sleep 3600"]
+    securityContext:
+      runAsUser: 65534


### PR DESCRIPTION
This PR allows users to specify a Pod manifest that will be used for the benchmark e.g. if you want to benchmark a different Pod Spec than the default one (e.g. compare different spec variants).

TODO:

- [ ] Add unit test
- [ ] Add documentation 
- [ ] Allow to specify Pod Template path